### PR TITLE
chore(workflow): add SDK parity dispatch workflow

### DIFF
--- a/.github/workflows/sdk-parity-dispatch.yml
+++ b/.github/workflows/sdk-parity-dispatch.yml
@@ -1,0 +1,17 @@
+name: SDK Parity Dispatch
+
+on:
+  push:
+    paths:
+      - "src/**"
+      - "composer.json"
+  pull_request:
+    paths:
+      - "src/**"
+      - "composer.json"
+  workflow_dispatch:
+
+jobs:
+  parity-dispatch:
+    uses: tapsilat/tapsilat-sdk-parity/.github/workflows/reusable-sdk-parity-dispatch.yml@main
+    secrets: inherit


### PR DESCRIPTION
- Introduced a new GitHub Actions workflow for SDK parity dispatch.
- Triggers on push and pull request events for changes in the `src` directory and `composer.json`.
- Utilizes a reusable workflow from the tapsilat/tapsilat-sdk-parity repository.